### PR TITLE
Composer config/docs incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
     }
   ],
   "require": {
-    "GIT_USER_ID/GIT_REPO_ID": "*@dev"
+    "zuora/codelibrary-php": "*@dev"
   }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "GIT_USER_ID/GIT_REPO_ID",
+    "name": "zuora/codelibrary-php",
     "description": "",
     "keywords": [
         "swagger",


### PR DESCRIPTION
The composer configuration and documentation did not properly reflect the package name. There were placeholders there instead.